### PR TITLE
Remove full logit distillation arg in trainer

### DIFF
--- a/distil_trainer.py
+++ b/distil_trainer.py
@@ -399,7 +399,6 @@ class DistilTrainer(BaseTrainer):
         # Reference model
         self.beta = args.beta
         self.alpha = args.alpha
-        self.full_logit_distillation = args.full_logit_distillation
         self.generate_from_teacher = args.generate_from_teacher
         if ref_model is not None:
             # If a reference model is provided, use it


### PR DESCRIPTION
The trainer is currently setting an argument for `full_logit_distillation`. This is causing the repo to not currently run out of the box, as found by [this](https://github.com/idanshen/Self-Distillation/issues/4) issue.

This PR simply removes the setting of this argument, as it is not referenced anywhere else in the repository. 